### PR TITLE
Expanding Support for HTTP Methods

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -16,7 +16,6 @@ import {
 import { ExpressHelperError } from './error';
 import { HttpMethod, RouterMethods } from './http';
 import { AbstractParsePipe, ParseEmptyPipe } from './validator';
-import * as console from 'console';
 
 declare module 'express-serve-static-core' {
   interface Request {
@@ -216,6 +215,91 @@ export function Put(url: string): MethodDecorator {
       {
         url,
         methods: [HttpMethod.PUT],
+        name: propertyKey,
+        controller: handler,
+      },
+      descriptor.value,
+    );
+  };
+}
+
+export function Patch(url: string): MethodDecorator {
+  return (target: unknown, propertyKey: string | symbol, descriptor: PropertyDescriptor): void => {
+    const handler = argumentsResolvedHandler(target, propertyKey, descriptor);
+
+    Reflect.defineMetadata(
+      requestMetadataKey,
+      {
+        url,
+        methods: [HttpMethod.PATCH],
+        name: propertyKey,
+        controller: handler,
+      },
+      descriptor.value,
+    );
+  };
+}
+
+export function Head(url: string): MethodDecorator {
+  return (target: unknown, propertyKey: string | symbol, descriptor: PropertyDescriptor): void => {
+    const handler = argumentsResolvedHandler(target, propertyKey, descriptor);
+
+    Reflect.defineMetadata(
+      requestMetadataKey,
+      {
+        url,
+        methods: [HttpMethod.HEAD],
+        name: propertyKey,
+        controller: handler,
+      },
+      descriptor.value,
+    );
+  };
+}
+
+export function CONNECT(url: string): MethodDecorator {
+  return (target: unknown, propertyKey: string | symbol, descriptor: PropertyDescriptor): void => {
+    const handler = argumentsResolvedHandler(target, propertyKey, descriptor);
+
+    Reflect.defineMetadata(
+      requestMetadataKey,
+      {
+        url,
+        methods: [HttpMethod.CONNECT],
+        name: propertyKey,
+        controller: handler,
+      },
+      descriptor.value,
+    );
+  };
+}
+
+export function Options(url: string): MethodDecorator {
+  return (target: unknown, propertyKey: string | symbol, descriptor: PropertyDescriptor): void => {
+    const handler = argumentsResolvedHandler(target, propertyKey, descriptor);
+
+    Reflect.defineMetadata(
+      requestMetadataKey,
+      {
+        url,
+        methods: [HttpMethod.OPTIONS],
+        name: propertyKey,
+        controller: handler,
+      },
+      descriptor.value,
+    );
+  };
+}
+
+export function Trace(url: string): MethodDecorator {
+  return (target: unknown, propertyKey: string | symbol, descriptor: PropertyDescriptor): void => {
+    const handler = argumentsResolvedHandler(target, propertyKey, descriptor);
+
+    Reflect.defineMetadata(
+      requestMetadataKey,
+      {
+        url,
+        methods: [HttpMethod.TRACE],
         name: propertyKey,
         controller: handler,
       },

--- a/src/http.ts
+++ b/src/http.ts
@@ -6,6 +6,10 @@ export enum HttpMethod {
   PATCH = 'PATCH',
   POST = 'POST',
   DELETE = 'DELETE',
+  HEAD = 'HEAD',
+  CONNECT = 'CONNECT',
+  OPTIONS = 'OPTIONS',
+  TRACE = 'TRACE',
 }
 
 export type RouterMethods = 'get' | 'post' | 'put' | 'delete' | 'patch';
@@ -19,14 +23,22 @@ export namespace HttpMethod {
     switch (method.replace(/\t/g, '').toUpperCase()) {
       case 'GET':
         return HttpMethod.GET;
-      case 'PUT':
-        return HttpMethod.PUT;
-      case 'PATCH':
-        return HttpMethod.PATCH;
       case 'POST':
         return HttpMethod.POST;
       case 'DELETE':
         return HttpMethod.DELETE;
+      case 'PUT':
+        return HttpMethod.PUT;
+      case 'PATCH':
+        return HttpMethod.PATCH;
+      case 'HEAD':
+        return HttpMethod.HEAD;
+      case 'CONNECT':
+        return HttpMethod.CONNECT;
+      case 'OPTIONS':
+        return HttpMethod.OPTIONS;
+      case 'TRACE':
+        return HttpMethod.TRACE;
       default:
         throw new ExpressHelperError(405, 'Unsupported Http Method');
     }


### PR DESCRIPTION
## 구현 기능
-  추가한 http 메서드
  - PATCH
  - HEAD
  - CONNECT
  - OPTIONS
  - TRACE

## 기타
```js
  @Head('/api/test')
  head(@Req() req: Request, @Res() res: Response) {
    res.setHeader('myHeader', 'test');
  }

  @Options('/api/test')
  options(@Req() req: Request, @Res() res: Response) {
    res.setHeader('Allow', 'GET, POST, PUT, DELETE');
    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
  }

  @Trace('/api/test')
  trace(@Req() req: Request, @Res() res: Response) {
    const requestHeaders = req.headers;
    return { requestHeaders };
  }
```
코드 실행으로 테스트 진행했습니다.

## Close
- close #10