### PR TITLE
Extract cookies from handler to controller

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,3 +37,7 @@ export interface BodyMetadata extends HandlerArgumentMetadata {}
 export interface AuthenticationMetadata extends HandlerArgumentMetadata {
   authMiddleware: Handler;
 }
+
+export interface CookieMetadata extends HandlerArgumentMetadata {
+  value: string;
+}


### PR DESCRIPTION
## Extract cookies from handler to controller

```typescript
@RestController()
export class CookieController {
  @Get('/cookie')
  cookie(@Cookie('example') id: string) {
    return id;
  }

  @Post('/set-cookie/:val')
  setCookie(@Res() response: Response, @Param('val') val: string) {
    console.log(val);
    response.cookie('example', val);
    return val;
  }
}
```

![image](https://github.com/express-helper/express-helper/assets/75921696/981e9dc8-5c9d-4405-bb3e-c8a9c498092c)


![image](https://github.com/express-helper/express-helper/assets/75921696/e9d02787-ce27-430f-add3-3ace060483b3)


* You now don't have to access the Request instance directly to extract cookies from the controller.


## Close
- close #11